### PR TITLE
XML Render plugin added and main pom.xml also modified

### DIFF
--- a/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/AbstractMigrationAnalysis.java
+++ b/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/AbstractMigrationAnalysis.java
@@ -31,10 +31,10 @@ abstract class AbstractMigrationAnalysis {
         try {
             commandLine = new PosixParser().parse(OPTIONS, args);
             String inputPath = commandLine.getOptionValue(OptionsFactory.OPTION_KEY_INPUT_PATH);
-            String outputType = commandLine.getOptionValue(OptionsFactory.OPTION_KEY_OUTPUT_TYPE);
+            String[] outputTypes = commandLine.getOptionValues(OptionsFactory.OPTION_KEY_OUTPUT_TYPE);
             String outputPath = commandLine.getOptionValue(OptionsFactory.OPTION_KEY_OUTPUT_PATH);
             String[] excludes = commandLine.getOptionValues(OptionsFactory.OPTION_KEY_EXCLUDE);
-            getExecutor(inputPath, outputType, outputPath, excludes).execute();
+            getExecutor(inputPath, outputTypes, outputPath, excludes).execute();
         } catch (ParseException e) {
             new HelpFormatter().printHelp("migration-analysis.[sh | bat] [OPTION]...", OPTIONS);
             exit(-1);
@@ -42,7 +42,7 @@ abstract class AbstractMigrationAnalysis {
 
     }
 
-    protected abstract MigrationAnalysisExecutor getExecutor(String inputPath, String outputType, String outputPath, String[] excludes);
+    protected abstract MigrationAnalysisExecutor getExecutor(String inputPath, String[] outputTypes, String outputPath, String[] excludes);
 
     protected abstract void exit(int code);
 }

--- a/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisBatchExecutor.java
+++ b/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisBatchExecutor.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.commandline;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.migrationanalyzer.analyze.AnalysisEngine;
+import org.springframework.migrationanalyzer.analyze.AnalysisResult;
+import org.springframework.migrationanalyzer.analyze.fs.FileSystem;
+import org.springframework.migrationanalyzer.analyze.fs.FileSystemFactory;
+import org.springframework.migrationanalyzer.analyze.fs.support.DirectoryFileSystemFactory;
+import org.springframework.migrationanalyzer.analyze.support.AnalysisEngineFactory;
+import org.springframework.migrationanalyzer.analyze.support.StandardAnalysisEngineFactory;
+import org.springframework.migrationanalyzer.render.RenderEngine;
+import org.springframework.migrationanalyzer.render.support.RenderEngineFactory;
+import org.springframework.migrationanalyzer.render.support.StandardRenderEngineFactory;
+
+final class CommandLineMigrationAnalysisBatchExecutor implements MigrationAnalysisExecutor {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final AnalysisEngineFactory analysisEngineFactory;
+
+    private final RenderEngineFactory renderEngineFactory;
+
+    private final FileSystemFactory fileSystemFactory;
+
+    private final String inputPath;
+
+    private final String outputPath;
+
+    private final String[] outputTypes;
+
+    private final String[] excludes;
+
+    private static final String[] DEFAULT_EXCLUDES = new String[0];
+
+    private static final String DEFAULT_OUTPUT_PATH = ".";
+
+    private final String[] allowedScanExtenstions = { "zip", "war", "ear" };
+
+    private File inputFile;
+
+    private File outputParentDir;
+
+    CommandLineMigrationAnalysisBatchExecutor(String inputPath, String[] outputTypes, String outputPath, String[] excludes) {
+        this(inputPath, outputTypes, outputPath, excludes, new StandardAnalysisEngineFactory(), new StandardRenderEngineFactory(),
+            new DirectoryFileSystemFactory());
+    }
+
+    CommandLineMigrationAnalysisBatchExecutor(String inputPath, String[] outputTypes, String outputPath, String[] excludes,
+        AnalysisEngineFactory analysisEngineFactory, RenderEngineFactory renderEngineFactory, FileSystemFactory fileSystemFactory) {
+        this.analysisEngineFactory = analysisEngineFactory;
+        this.renderEngineFactory = renderEngineFactory;
+        this.fileSystemFactory = fileSystemFactory;
+        this.inputPath = inputPath;
+        this.outputTypes = outputTypes;
+        this.outputPath = outputPath == null ? DEFAULT_OUTPUT_PATH : outputPath;
+        this.excludes = excludes == null ? DEFAULT_EXCLUDES : excludes;
+    }
+
+    @Override
+    public void execute() {
+        List<FileNameStub> filesDetected = new ArrayList<FileNameStub>();
+        PrintWriter pw = new PrintWriter(System.out);
+        this.inputFile = new File(this.inputPath);
+
+        if (!this.inputFile.exists()) {
+            this.logger.error("{} file doesn't exist", this.inputFile);
+
+            return;
+        }
+
+        scanFilesRecursive(this.inputFile, filesDetected);
+
+        this.logger.info("========={} J2EE files Detected==========", filesDetected.size());
+        for (FileNameStub fileStub : filesDetected) {
+            this.logger.info("{}", fileStub.getRelativePath());
+        }
+        this.logger.info("========================================");
+
+        this.outputParentDir = new File(this.outputPath);
+        if (!this.outputParentDir.exists()) {
+            this.outputParentDir.mkdir();
+        }
+        for (FileNameStub fileStub : filesDetected) {
+            // pw.println(String.format("Analyzing %s", fileName));
+            String outputFileName = new File(this.outputParentDir, fileStub.getRelativePath()).getAbsolutePath();
+            String printName = (fileStub.getRelativePath().length() == 0 ? fileStub.getAbsolutePath() : fileStub.getRelativePath());
+            this.logger.debug("Analyzing Input file: {} to Output file: {}", printName, outputFileName);
+            this.logger.info("Analyzing {}", printName);
+            executeFile(fileStub.getAbsolutePath(), outputFileName, this.excludes);
+
+        }
+    }
+
+    private void scanFilesRecursive(File file, List<FileNameStub> filesDetected) {
+        if (file.isDirectory()) {
+            for (File childFile : file.listFiles(this.filter)) {
+                scanFilesRecursive(childFile, filesDetected);
+            }
+        } else {
+            String relative = this.inputFile.toURI().relativize(file.toURI()).getPath();
+
+            filesDetected.add(new FileNameStub(file.getAbsolutePath(), relative));
+        }
+    }
+
+    private void executeFile(String inputFileName, String outputFileName, String[] excludes) {
+        FileSystem fileSystem = createFileSystem(inputFileName);
+        AnalysisEngine analysisEngine = this.analysisEngineFactory.createAnalysisEngine(fileSystem, excludes);
+        List<RenderEngine> renderEngines = new ArrayList<RenderEngine>();
+        for (String outputType : this.outputTypes) {
+            RenderEngine renderEngine = this.renderEngineFactory.create(outputType, outputFileName);
+            if (renderEngine != null) {
+                renderEngines.add(renderEngine);
+            }
+        }
+
+        AnalysisResult analysis = analysisEngine.analyze();
+        for (RenderEngine renderEngine : renderEngines) {
+            renderEngine.render(analysis);
+        }
+
+        fileSystem.cleanup();
+    }
+
+    private FileSystem createFileSystem(String fileName) {
+        FileSystem fileSystem;
+
+        File inputFile = new File(fileName);
+        try {
+            fileSystem = this.fileSystemFactory.createFileSystem(inputFile);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format("Failed to create FileSystem for input '" + inputFile.getAbsolutePath() + "'"), e);
+        }
+        return fileSystem;
+    }
+
+    FilenameFilter filter = new FilenameFilter() {
+
+        @Override
+        public boolean accept(File dir, String name) {
+            for (String extension : CommandLineMigrationAnalysisBatchExecutor.this.allowedScanExtenstions) {
+                if (name.endsWith("." + extension)) {
+                    return true;
+                }
+            }
+
+            return new File(dir, name).isDirectory();
+        }
+    };
+
+    private class FileNameStub {
+
+        String absolutePath;
+
+        String relativePath;
+
+        public FileNameStub(String absolutePath, String relativePath) {
+            this.absolutePath = absolutePath;
+            this.relativePath = relativePath;
+        }
+
+        public String getAbsolutePath() {
+            return this.absolutePath;
+        }
+
+        public void setAbsolutePath(String absolutePath) {
+            this.absolutePath = absolutePath;
+        }
+
+        public String getRelativePath() {
+            return this.relativePath;
+        }
+
+        public void setRelativePath(String relativePath) {
+            this.relativePath = relativePath;
+        }
+
+    }
+}

--- a/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/MigrationAnalysis.java
+++ b/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/MigrationAnalysis.java
@@ -36,8 +36,8 @@ public final class MigrationAnalysis extends AbstractMigrationAnalysis {
     }
 
     @Override
-    protected MigrationAnalysisExecutor getExecutor(String inputPath, String outputType, String outputPath, String[] excludes) {
-        return new CommandLineMigrationAnalysisExecutor(inputPath, outputType, outputPath, excludes);
+    protected MigrationAnalysisExecutor getExecutor(String inputPath, String[] outputTypes, String outputPath, String[] excludes) {
+        return new CommandLineMigrationAnalysisExecutor(inputPath, outputTypes, outputPath, excludes);
     }
 
     @Override

--- a/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/MigrationBatchAnalysis.java
+++ b/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/MigrationBatchAnalysis.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.commandline;
+
+/**
+ * Main entry point to the Migration Analysis application via the command line
+ * <p />
+ * 
+ * <strong>Concurrent Semantics</strong><br />
+ * 
+ * Thread-safe
+ */
+public final class MigrationBatchAnalysis extends AbstractMigrationAnalysis {
+
+    /**
+     * Main method for invoking the application
+     * 
+     * @param args Command line arguments
+     */
+    public static void main(String[] args) {
+        new MigrationBatchAnalysis().run(args);
+    }
+
+    @Override
+    protected MigrationAnalysisExecutor getExecutor(String inputPath, String[] outputTypes, String outputPath, String[] excludes) {
+        return new CommandLineMigrationAnalysisBatchExecutor(inputPath, outputTypes, outputPath, excludes);
+    }
+
+    @Override
+    protected void exit(int code) {
+        System.exit(code);
+    }
+}

--- a/command-line/src/test/java/org/springframework/migrationanalyzer/commandline/AbstraktMigrationAnalysisTests.java
+++ b/command-line/src/test/java/org/springframework/migrationanalyzer/commandline/AbstraktMigrationAnalysisTests.java
@@ -44,7 +44,7 @@ public class AbstraktMigrationAnalysisTests {
         private volatile int code;
 
         @Override
-        protected MigrationAnalysisExecutor getExecutor(String inputPath, String outputType, String outpathPath, String[] excludes) {
+        protected MigrationAnalysisExecutor getExecutor(String inputPath, String[] outputTypes, String outpathPath, String[] excludes) {
             return this.executor;
         }
 

--- a/command-line/src/test/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisExecutorTests.java
+++ b/command-line/src/test/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisExecutorTests.java
@@ -40,8 +40,8 @@ public class CommandLineMigrationAnalysisExecutorTests {
         StubAnalysisEngineFactory analysisEngineFactory = new StubAnalysisEngineFactory();
         StubRenderEngineFactory renderEngineFactory = new StubRenderEngineFactory();
 
-        CommandLineMigrationAnalysisExecutor executor = new CommandLineMigrationAnalysisExecutor("input", "type", "output", new String[0],
-            analysisEngineFactory, renderEngineFactory, new StubFileSystemFactory());
+        CommandLineMigrationAnalysisExecutor executor = new CommandLineMigrationAnalysisExecutor("input", new String[] { "type" }, "output",
+            new String[0], analysisEngineFactory, renderEngineFactory, new StubFileSystemFactory());
         executor.execute();
 
         assertEquals(1, analysisEngineFactory.analysisEngines.size());
@@ -56,7 +56,7 @@ public class CommandLineMigrationAnalysisExecutorTests {
         StubAnalysisEngineFactory analysisEngineFactory = new StubAnalysisEngineFactory();
         StubRenderEngineFactory renderEngineFactory = new StubRenderEngineFactory();
 
-        CommandLineMigrationAnalysisExecutor executor = new CommandLineMigrationAnalysisExecutor("input", "type", "output", null,
+        CommandLineMigrationAnalysisExecutor executor = new CommandLineMigrationAnalysisExecutor("input", new String[] { "type" }, "output", null,
             analysisEngineFactory, renderEngineFactory, new StubFileSystemFactory());
 
         executor.execute();
@@ -71,8 +71,8 @@ public class CommandLineMigrationAnalysisExecutorTests {
         StubAnalysisEngineFactory analysisEngineFactory = new StubAnalysisEngineFactory();
         StubRenderEngineFactory renderEngineFactory = new StubRenderEngineFactory();
 
-        CommandLineMigrationAnalysisExecutor executor = new CommandLineMigrationAnalysisExecutor("input", "type", null, new String[0],
-            analysisEngineFactory, renderEngineFactory, new StubFileSystemFactory());
+        CommandLineMigrationAnalysisExecutor executor = new CommandLineMigrationAnalysisExecutor("input", new String[] { "type" }, null,
+            new String[0], analysisEngineFactory, renderEngineFactory, new StubFileSystemFactory());
 
         executor.execute();
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -44,6 +44,11 @@
 			<artifactId>util</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.migrationanalyzer</groupId>
+			<artifactId>xml-render</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<module>packaging</module>
 		<module>render</module>
 		<module>util</module>
+		<module>xml-render</module>
 	</modules>
 	
 	<profiles>

--- a/xml-render/pom.xml
+++ b/xml-render/pom.xml
@@ -1,0 +1,63 @@
+<project
+		xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="
+			http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.migrationanalyzer</groupId>
+		<artifactId>spring-migration-analyzer-parent</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>xml-render</artifactId>
+	<packaging>jar</packaging>
+	<name>XML Rendering engine</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.migrationanalyzer</groupId>
+			<artifactId>analyze</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.migrationanalyzer</groupId>
+			<artifactId>contributions</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.migrationanalyzer</groupId>
+			<artifactId>render</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/XMLRender.java
+++ b/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/XMLRender.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.render.support.xml;
+
+import java.util.Set;
+
+import org.springframework.migrationanalyzer.analyze.AnalysisResultEntry;
+import org.springframework.migrationanalyzer.analyze.fs.FileSystemEntry;
+import org.springframework.migrationanalyzer.contributions.apiusage.ApiUsage;
+import org.springframework.migrationanalyzer.contributions.deploymentdescriptors.DeploymentDescriptor;
+import org.springframework.migrationanalyzer.contributions.ejb.EntityBean;
+import org.springframework.migrationanalyzer.contributions.ejb.SessionBean;
+import org.springframework.migrationanalyzer.render.support.xml.entity.XMLApplication;
+import org.springframework.migrationanalyzer.render.support.xml.entity.XMLFileSystemEntry;
+import org.springframework.migrationanalyzer.render.support.xml.entity.XMLRoot;
+
+import com.thoughtworks.xstream.XStream;
+
+public class XMLRender {
+
+    XStream xstream = null;
+    
+    public XMLRender() {
+        this.xstream = new XStream();
+        this.xstream.alias("analysisResultEntry", AnalysisResultEntry.class);
+        this.xstream.alias("fileSystemEntry", FileSystemEntry.class);
+        this.xstream.alias("apiUsage", ApiUsage.class);
+        this.xstream.alias("deploymentDescriptor", DeploymentDescriptor.class);
+        this.xstream.alias("entityBean", EntityBean.class);
+        // xstream.alias("messageDrivenBean");
+        this.xstream.alias("sessionBean", SessionBean.class);
+        // xstream.alias("springConfiguration", SpringConfiguration.class);
+        this.xstream.alias("fileSystemEntry", XMLFileSystemEntry.class);
+        this.xstream.alias("app", XMLApplication.class);
+        this.xstream.alias("root", XMLRoot.class);
+    }
+
+    /*
+     * @Test public void testXStream() { ApiUsage a = new ApiUsage(ApiUsageType.FIELD, "apiName", "user",
+     * "usageDescription", "guidanceView", MigrationCost.LOW); XStream xstream = new XStream();
+     * xstream.alias("ApiUsage", ApiUsage.class); String xml = xstream.toXML(a); System.out.println(xml); }
+     */
+
+    public String getXMLRootToString(XMLRoot root) {
+        return this.xstream.toXML(root);
+    }
+
+    public <T> String getXMLString(Class<?> resultType, Set<AnalysisResultEntry<T>> entries) {
+        StringBuffer sb = new StringBuffer();
+        for (AnalysisResultEntry<T> analysisResultEntry : entries) {
+            T result = analysisResultEntry.getResult();
+
+            // System.out.println(xstream.toXML(analysisResultEntry));
+
+            sb.append(this.xstream.toXML(result));
+        }
+
+        return sb.toString();
+    }
+}

--- a/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/XMLRenderEngine.java
+++ b/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/XMLRenderEngine.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.render.support.xml;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.migrationanalyzer.analyze.AnalysisResult;
+import org.springframework.migrationanalyzer.analyze.AnalysisResultEntry;
+import org.springframework.migrationanalyzer.analyze.fs.FileSystemEntry;
+import org.springframework.migrationanalyzer.render.RenderEngine;
+import org.springframework.migrationanalyzer.render.support.xml.entity.XMLApplication;
+import org.springframework.migrationanalyzer.render.support.xml.entity.XMLFileSystemEntry;
+import org.springframework.migrationanalyzer.render.support.xml.entity.XMLRoot;
+
+public class XMLRenderEngine implements RenderEngine {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private String fileName = "";
+
+    private String outputPath = "";
+
+    public XMLRenderEngine(String outputPath) {
+        if (!new File(outputPath).exists()) {
+            new File(outputPath).mkdirs();
+        }
+        this.fileName = outputPath + "/rawdata.xml";
+        this.outputPath = outputPath;
+    }
+
+    @Override
+    public void render(AnalysisResult analysisResult) {
+        this.logger.info("Starting XML rendering");
+        StringBuffer sb = new StringBuffer();
+
+        XMLRoot root = new XMLRoot();
+        XMLApplication app = new XMLApplication(this.outputPath);
+
+        Set<FileSystemEntry> fileSystemEntries = analysisResult.getFileSystemEntries();
+
+        XMLRender x = new XMLRender();
+
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+
+        for (FileSystemEntry fileSystemEntry : fileSystemEntries) {
+
+            XMLFileSystemEntry xmlFileEntry = new XMLFileSystemEntry(fileSystemEntry.getName(), new HashSet<Object>());
+
+            AnalysisResult entryResult = analysisResult.getResultForEntry(fileSystemEntry);
+
+            for (Class<?> resultType : entryResult.getResultTypes()) {
+
+                for (AnalysisResultEntry<?> resultEntry : entryResult.getResultEntries(resultType)) {
+                    xmlFileEntry.getResults().add(resultEntry.getResult());
+                }
+
+            }
+            app.getFileEntries().add(xmlFileEntry);
+        }
+
+        root.getApplications().add(app);
+
+        sb.append(x.getXMLRootToString(root));
+
+        writeToFile(sb);
+
+        this.logger.info("Finished XML rendering");
+
+    }
+
+    private void writeToFile(StringBuffer sb) {
+        File file = new File(this.fileName);
+        if (file.exists()) {
+            file.delete();
+        }
+
+        try {
+            file.createNewFile();
+            PrintWriter printWriter = new PrintWriter(file);
+            printWriter.println(sb.toString());
+            printWriter.flush();
+            printWriter.close();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/XMLRenderEngineSubFactory.java
+++ b/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/XMLRenderEngineSubFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.render.support.xml;
+
+import org.springframework.migrationanalyzer.render.RenderEngine;
+import org.springframework.migrationanalyzer.render.support.RenderEngineSubFactory;
+
+public class XMLRenderEngineSubFactory implements RenderEngineSubFactory {
+
+    private static final String OUTPUT_TYPE_XML = "xml";
+
+    @Override
+    public boolean canRender(String outputType) {
+        return OUTPUT_TYPE_XML.equals(outputType);
+    }
+
+    @Override
+    public RenderEngine create(String outputPath) {
+        return new XMLRenderEngine(outputPath);
+    }
+
+}

--- a/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/entity/XMLApplication.java
+++ b/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/entity/XMLApplication.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.render.support.xml.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class XMLApplication {
+
+    private String name;
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    private List<XMLFileSystemEntry> fileEntries = null;
+
+    public XMLApplication() {
+        this.fileEntries = new ArrayList<XMLFileSystemEntry>();
+    }
+
+    public XMLApplication(String name) {
+        this.fileEntries = new ArrayList<XMLFileSystemEntry>();
+        this.name = name;
+    }
+
+    public List<XMLFileSystemEntry> getFileEntries() {
+        return this.fileEntries;
+    }
+
+    public void setFileEntries(List<XMLFileSystemEntry> fileEntries) {
+        this.fileEntries = fileEntries;
+    }
+
+}

--- a/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/entity/XMLFileSystemEntry.java
+++ b/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/entity/XMLFileSystemEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.render.support.xml.entity;
+
+import java.util.Set;
+
+public class XMLFileSystemEntry {
+
+    private String name;
+
+    private Set<Object> results;
+
+    public Set<Object> getResults() {
+        return this.results;
+    }
+
+    public void setResults(Set<Object> results) {
+        this.results = results;
+    }
+
+    public XMLFileSystemEntry(String name, Set<Object> results) {
+        this.name = name;
+        this.results = results;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/entity/XMLRoot.java
+++ b/xml-render/src/main/java/org/springframework/migrationanalyzer/render/support/xml/entity/XMLRoot.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.render.support.xml.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class XMLRoot {
+
+    private List<XMLApplication> applications = null;
+
+    public XMLRoot() {
+        this.applications = new ArrayList<XMLApplication>();
+    }
+
+    public List<XMLApplication> getApplications() {
+        return this.applications;
+    }
+
+    public void setApplications(List<XMLApplication> applications) {
+        this.applications = applications;
+    }
+
+}


### PR DESCRIPTION
I have added XML Render plugin which will convert Analysis Result
objects to XML using XStream plugin and write to raw data.xml file.
This XML file can be handy to prepare different reports or extract some
specific details.

The project contains Maven directory structure as expected in other SMA
projects, and I have also modified main pom.xml to build XML Render
project.

Testing: -
I have tested output from "mvn clean install" and tested
.migration-analysis.sh with -t xml and generated xml successfully.
