### PR TITLE
Fix the version of the Sonar plugin to be used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>sonar-maven-plugin</artifactId>
+					<version>2.0</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>2.2</version>


### PR DESCRIPTION
This commit fixes the version of the Sonar plugin to be used to per the
instructions at
http://docs.codehaus.org/display/SONAR/How+to+fix+version+of+Maven+plugin.
The plugin is fixed to version 2.0 to support Maven 3 usage only. This change
should make it possible to run `mvn sonar:sonar` rather than the current `mvn
org.codehaus.sonar:sonar-maven3-plugin:${bamboo.sonar.version}:sonar`
