### PR TITLE
Recursively scanning archive files in directory

### DIFF
--- a/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisExecutor.java
+++ b/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisExecutor.java
@@ -83,6 +83,12 @@ final class CommandLineMigrationAnalysisExecutor implements MigrationAnalysisExe
     public void execute() {
         this.inputFile = new File(this.inputPath);
 
+        if (!this.inputFile.exists()) {
+            this.logger.error("{} file doesn't exist", this.inputFile);
+            this.logger.info("Exiting, provide valid input file path");
+            return;
+        }
+
         if (this.inputFile.isDirectory()) {
             List<FileNameStub> filesDetected = new ArrayList<FileNameStub>();
 

--- a/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisExecutor.java
+++ b/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/CommandLineMigrationAnalysisExecutor.java
@@ -17,8 +17,14 @@
 package org.springframework.migrationanalyzer.commandline;
 
 import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.migrationanalyzer.analyze.AnalysisEngine;
 import org.springframework.migrationanalyzer.analyze.AnalysisResult;
 import org.springframework.migrationanalyzer.analyze.fs.FileSystem;
@@ -29,8 +35,11 @@ import org.springframework.migrationanalyzer.analyze.support.StandardAnalysisEng
 import org.springframework.migrationanalyzer.render.RenderEngine;
 import org.springframework.migrationanalyzer.render.support.RenderEngineFactory;
 import org.springframework.migrationanalyzer.render.support.StandardRenderEngineFactory;
+import org.springframework.migrationanalyzer.util.ZipUtils;
 
 final class CommandLineMigrationAnalysisExecutor implements MigrationAnalysisExecutor {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final AnalysisEngineFactory analysisEngineFactory;
 
@@ -50,6 +59,10 @@ final class CommandLineMigrationAnalysisExecutor implements MigrationAnalysisExe
 
     private static final String DEFAULT_OUTPUT_PATH = ".";
 
+    private File inputFile;
+
+    private File outputParentDir;
+
     CommandLineMigrationAnalysisExecutor(String inputPath, String outputType, String outputPath, String[] excludes) {
         this(inputPath, outputType, outputPath, excludes, new StandardAnalysisEngineFactory(), new StandardRenderEngineFactory(),
             new DirectoryFileSystemFactory());
@@ -68,24 +81,107 @@ final class CommandLineMigrationAnalysisExecutor implements MigrationAnalysisExe
 
     @Override
     public void execute() {
-        FileSystem fileSystem = createFileSystem();
-        AnalysisEngine analysisEngine = this.analysisEngineFactory.createAnalysisEngine(fileSystem, this.excludes);
-        RenderEngine renderEngine = this.renderEngineFactory.create(this.outputType, this.outputPath);
+        this.inputFile = new File(this.inputPath);
+
+        if (this.inputFile.isDirectory()) {
+            List<FileNameStub> filesDetected = new ArrayList<FileNameStub>();
+
+            scanFilesRecursive(this.inputFile, filesDetected);
+
+            this.logger.info("========={} Archive files Detected==========", filesDetected.size());
+            for (FileNameStub fileStub : filesDetected) {
+                this.logger.info("{}", fileStub.getRelativePath());
+            }
+            this.logger.info("========================================");
+
+            this.outputParentDir = new File(this.outputPath);
+            if (!this.outputParentDir.exists()) {
+                this.outputParentDir.mkdir();
+            }
+            for (FileNameStub fileStub : filesDetected) {
+                String outputFileName = new File(this.outputParentDir, fileStub.getRelativePath()).getAbsolutePath();
+                outputFileName = outputFileName + "-results";
+                String printName = (fileStub.getRelativePath().length() == 0 ? fileStub.getAbsolutePath() : fileStub.getRelativePath());
+                this.logger.debug("Analyzing Input file: {} to Output file: {}", printName, outputFileName);
+                this.logger.info("Analyzing {}", printName);
+                executeFile(fileStub.getAbsolutePath(), outputFileName, this.excludes);
+
+            }
+        } else {
+            executeFile(this.inputPath, this.outputPath, this.excludes);
+        }
+    }
+
+    private void scanFilesRecursive(File file, List<FileNameStub> filesDetected) {
+        if (file.isDirectory()) {
+            for (File childFile : file.listFiles(this.filter)) {
+                scanFilesRecursive(childFile, filesDetected);
+            }
+        } else {
+            String relative = this.inputFile.toURI().relativize(file.toURI()).getPath();
+
+            filesDetected.add(new FileNameStub(file.getAbsolutePath(), relative));
+        }
+    }
+
+    private void executeFile(String inputFileName, String outputFileName, String[] excludes) {
+        FileSystem fileSystem = createFileSystem(inputFileName);
+        AnalysisEngine analysisEngine = this.analysisEngineFactory.createAnalysisEngine(fileSystem, excludes);
+        RenderEngine renderEngine = this.renderEngineFactory.create(this.outputType, outputFileName);
 
         AnalysisResult analysis = analysisEngine.analyze();
         renderEngine.render(analysis);
+
         fileSystem.cleanup();
     }
 
-    private FileSystem createFileSystem() {
+    private FileSystem createFileSystem(String fileName) {
         FileSystem fileSystem;
 
-        File inputFile = new File(this.inputPath);
+        File inputFile = new File(fileName);
         try {
             fileSystem = this.fileSystemFactory.createFileSystem(inputFile);
         } catch (IOException e) {
             throw new IllegalArgumentException(String.format("Failed to create FileSystem for input '" + inputFile.getAbsolutePath() + "'"), e);
         }
         return fileSystem;
+    }
+
+    private final FileFilter filter = new FileFilter() {
+
+        @Override
+        public boolean accept(File file) {
+
+            if (file.isDirectory()) {
+                return true;
+            }
+
+            try {
+                return ZipUtils.isZipFile(new FileInputStream(file));
+            } catch (IOException e) {
+                return false;
+            }
+        }
+    };
+
+    private class FileNameStub {
+
+        private final String absolutePath;
+
+        private final String relativePath;
+
+        public FileNameStub(String absolutePath, String relativePath) {
+            this.absolutePath = absolutePath;
+            this.relativePath = relativePath;
+        }
+
+        public String getAbsolutePath() {
+            return this.absolutePath;
+        }
+
+        public String getRelativePath() {
+            return this.relativePath;
+        }
+
     }
 }

--- a/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/OptionsFactory.java
+++ b/command-line/src/main/java/org/springframework/migrationanalyzer/commandline/OptionsFactory.java
@@ -34,7 +34,7 @@ final class OptionsFactory {
         Options options = new Options();
 
         options.addOption(OptionBuilder //
-        .withDescription("The path to the input location") //
+        .withDescription("The path to the input location, if input location is directory then it will scan all sub-directories recursively.") //
         .isRequired() //
         .hasArg() //
         .withArgName("inputPath") //


### PR DESCRIPTION
If input path is archive file, then system will do as before but if it's directory it will find archive files recursively and run analysis on each archive file and store results into dedicated directories inside output directory. For example, if there is an archive file inputdir/timetowork/timtowork.ear then result directory for timtowork.ear would be outputdir/timetowork/timtowork.ear-results.

And test cases are modified and corrected.
