### PR TITLE
Organize archive file entries by archive files in index file.

### DIFF
--- a/render/src/main/java/org/springframework/migrationanalyzer/render/support/html/StandardHtmlFileSystemEntryRenderer.java
+++ b/render/src/main/java/org/springframework/migrationanalyzer/render/support/html/StandardHtmlFileSystemEntryRenderer.java
@@ -20,8 +20,6 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 
 import org.springframework.migrationanalyzer.analyze.AnalysisResult;
 import org.springframework.migrationanalyzer.analyze.fs.FileSystemEntry;
@@ -29,6 +27,7 @@ import org.springframework.migrationanalyzer.render.ByFileSystemEntryController;
 import org.springframework.migrationanalyzer.render.OutputPathGenerator;
 import org.springframework.migrationanalyzer.render.support.source.SourceAccessor;
 import org.springframework.migrationanalyzer.util.IoUtils;
+import org.springframework.migrationanalyzer.util.Tree;
 
 @SuppressWarnings("rawtypes")
 final class StandardHtmlFileSystemEntryRenderer implements HtmlFileSystemEntryRenderer {
@@ -50,6 +49,8 @@ final class StandardHtmlFileSystemEntryRenderer implements HtmlFileSystemEntryRe
     private final ViewRenderer viewRenderer;
 
     private final WriterFactory writerFactory;
+
+    public static final char pathSeparator = '/';
 
     StandardHtmlFileSystemEntryRenderer(Set<ByFileSystemEntryController> fileSystemEntryControllers, ViewRenderer viewRenderer,
         RootAwareOutputPathGenerator outputPathGenerator, WriterFactory writerFactory, SourceAccessor sourceAccessor) {
@@ -101,21 +102,36 @@ final class StandardHtmlFileSystemEntryRenderer implements HtmlFileSystemEntryRe
     }
 
     private Map<String, Object> createContentsModel(Set<FileSystemEntry> fileSystemEntries, OutputPathGenerator locationAwarePathGenerator) {
-        Map<String, Set<String>> entryUrls = new TreeMap<String, Set<String>>();
+        Tree<String> rootTree = new Tree<String>(Character.toString(pathSeparator));
         for (FileSystemEntry fileSystemEntry : fileSystemEntries) {
-            String baseName = getBaseName(fileSystemEntry.getName());
-            if (baseName != null) {
-                Set<String> urls = entryUrls.get(baseName);
-                if (urls == null) {
-                    urls = new TreeSet<String>();
-                    entryUrls.put(baseName, urls);
+            int index = 0;
+            int baseIndex = 0;
+            Tree<String> baseTree = rootTree;
+            String fileName = fileSystemEntry.getName();
+            while (true) {
+                if (index >= fileName.length()) {
+                    break;
                 }
-                urls.add(locationAwarePathGenerator.generatePathFor(fileSystemEntry));
+                char c = fileName.charAt(index);
+                if ((c == '.') && ((index + 4) < fileName.length())) {
+                    if (fileName.charAt(index + 4) == pathSeparator) {
+                        String substring = fileName.substring(index, index + 4);
+                        if (substring.equals(".ear") || substring.equals(".war") || substring.equals(".jar") || substring.equals(".rar")
+                            || substring.equals(".zip")) {
+                            substring = fileName.substring(baseIndex, index + 4);
+                            baseTree = baseTree.addChildIfAbsent(substring);
+                            baseIndex = index + 4;
+                        }
+                        index = index + 4;
+                    }
+                }
+                index++;
             }
+            baseTree = baseTree.addChildIfAbsent(getBaseName(fileName));
+            baseTree = baseTree.addChildIfAbsent(locationAwarePathGenerator.generatePathFor(fileSystemEntry));
         }
-
         Map<String, Object> model = new HashMap<String, Object>();
-        model.put("entryUrls", entryUrls);
+        model.put("treeUrls", rootTree);
         return model;
     }
 

--- a/render/src/main/resources/org/springframework/migrationanalyzer/render/support/html/css/style.css
+++ b/render/src/main/resources/org/springframework/migrationanalyzer/render/support/html/css/style.css
@@ -160,6 +160,10 @@ h3.moduleHdr {
 	display:block;
 }
 
+.treeIndex li {
+	margin:1px 0px 0px 3px;	
+}
+
 #rail-resize, #rail-resize-vert {
     border-left: #E0E0E0 solid 1px;
     border-right: #E0E0E0 solid 1px;

--- a/render/src/main/resources/org/springframework/migrationanalyzer/render/support/html/html-file-contents.ftl
+++ b/render/src/main/resources/org/springframework/migrationanalyzer/render/support/html/html-file-contents.ftl
@@ -2,23 +2,43 @@
 <head>
   <title>File System Entries</title>
   <link rel="stylesheet" type="text/css" href="../css/style.css">
+  <script type="text/javascript" src="../js/script.js"></script>
+  </style>
 </head>
 <body>
 
 
-<div id="module">
-
-<#assign names = entryUrls?keys>
-  <ul>
-<#list names as name>
-<#assign urls = entryUrls[name]>
-<#list urls as url>
-    <li><a href="${url}" target="content">${name}</a></li>
-</#list>
-</#list>
-  </ul>
-  
+<div id="module" class="treeIndex">
+	<ul>
+		<#list treeUrls.getChildren() as child>
+			<@print tree=child/>
+		</#list>
+	</ul>
 </div>
 
 </body>
 </html>
+
+<#macro print tree>
+	<#if tree.isLeaf() == false>
+		<#if tree.isFirstChildLeaf() == true>
+				<#list tree.getChildren() as child>
+					  <li><a href="${child.head}" target="content">${tree.head}</a></li>
+				</#list>
+		<#else>
+			<li> 
+				<div class="archive">
+					<span class="toggle" onClick="toggle('${tree.head}', this)">[-]</span>
+					${tree.head} 
+				</div>
+				<div id="${tree.head}">							
+					<ul>
+						<#list tree.getChildren() as child>	
+							<@print tree=child/>
+						</#list>
+					</ul>	
+				</div>
+			</li>
+		</#if>
+	</#if>
+</#macro> 

--- a/util/src/main/java/org/springframework/migrationanalyzer/util/Tree.java
+++ b/util/src/main/java/org/springframework/migrationanalyzer/util/Tree.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.migrationanalyzer.util;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.TreeSet;
+
+public final class Tree<T extends Comparable<T>> implements Comparable<Tree<T>> {
+
+    private final T head;
+
+    private final TreeSet<Tree<T>> children = new TreeSet<Tree<T>>();
+
+    private Tree<T> parent = null;
+
+    private final HashMap<T, Tree<T>> locatorMap = new HashMap<T, Tree<T>>();
+
+    public Tree(T head) {
+        this.head = head;
+        this.locatorMap.put(head, this);
+    }
+
+    public Tree<T> addChild(T child) {
+        Tree<T> t = new Tree<T>(child);
+        this.children.add(t);
+        t.parent = this;
+        this.locatorMap.put(child, t);
+        return t;
+    }
+
+    public Tree<T> addChildIfAbsent(T element) {
+        Tree<T> tmpTree = this.locatorMap.get(element);
+        if (tmpTree == null) {
+            tmpTree = addChild(element);
+        }
+        return tmpTree;
+    }
+
+    public T getHead() {
+        return this.head;
+    }
+
+    public Tree<T> getTree(T element) {
+        return this.locatorMap.get(element);
+    }
+
+    public boolean hasElemenent(T element) {
+        return this.locatorMap.get(element) == null;
+    }
+
+    public Tree<T> getParent() {
+        return this.parent;
+    }
+
+    public Collection<Tree<T>> getChildren() {
+        return this.children;
+    }
+
+    public boolean isLeaf() {
+        return this.children.size() == 0;
+    }
+
+    public boolean isFirstChildLeaf() {
+        return (this.children.first()).children.size() == 0;
+    }
+
+    @Override
+    public String toString() {
+        return printTree(0);
+    }
+
+    public String printTree(int increment) {
+        String s = "";
+        String inc = "";
+        for (int i = 0; i < increment; i++) {
+            inc = inc + " ";
+        }
+        s = inc + this.head;
+        for (Tree<T> child : this.children) {
+            s = s + "\n" + child.printTree(increment + 2);
+        }
+        return s;
+    }
+
+    @Override
+    public int compareTo(Tree<T> tree2) {
+        return this.head.compareTo(tree2.head);
+    }
+}


### PR DESCRIPTION
Currently file entries are shown in alphabetical order on left side of index, this change would organize files by archive flies and possibly nested archive files. I have used existing expnding/collapsing JS capability, but we can add better UI later on.
